### PR TITLE
fixed epoch range in boost.py

### DIFF
--- a/boost.py
+++ b/boost.py
@@ -267,7 +267,7 @@ def main(args):
     pseudo_labels = -torch.ones(dataset_train.__len__(), dtype=torch.long)
     start_time = time.time()
     max_accuracy = 0.0
-    for epoch in range(args.start_epoch, args.epochs):
+    for epoch in range(args.start_epoch, args.start_epoch + args.epochs):
         if args.distributed:
             data_loader_train.sampler.set_epoch(epoch)
         train_stats, pseudo_labels = boost_one_epoch(


### PR DESCRIPTION
`args.start_epoch` depends is the last epoch of training, therefore might be 1000 if one loads checkpoint-999.
Therefore `range(args.start_epoch, args.epochs)` = `range(1000, 200)` => the loop is not executed